### PR TITLE
fix - Removing unnecessary code

### DIFF
--- a/test/DelegateContractV0.t.sol
+++ b/test/DelegateContractV0.t.sol
@@ -40,8 +40,6 @@ contract DelegateContractV0Test is Test {
         calls[0] = DelegateContractV0.Call({data: "", to: bob.addr, value: alice.addr.balance});
 
         vm.signAndAttachDelegation(address(delegateContract), alice.privateKey);
-        (bool success,) = address(0).call(""); // execute a call to submit the delegation tx
-        require(success);
 
         assertGt(alice.addr.code.length, 0);
 

--- a/test/DelegateContractV1.t.sol
+++ b/test/DelegateContractV1.t.sol
@@ -36,7 +36,6 @@ contract DelegateContractV1Test is Test {
     function test_noGuardiansInAccounts() public {
         vm.signAndAttachDelegation(address(delegateContract), alice.privateKey);
         vm.signAndAttachDelegation(address(delegateContract), bob.privateKey);
-        address(0).call(""); // by design, anyone with the signed authorizations can attach and submit the tx
 
         assertGt(alice.addr.code.length, 0);
         assertGt(bob.addr.code.length, 0);

--- a/test/DelegateContractV2.t.sol
+++ b/test/DelegateContractV2.t.sol
@@ -26,8 +26,6 @@ contract DelegateContractV2Test is Test {
         vm.deal(alice.addr, 1 ether);
 
         vm.signAndAttachDelegation(address(delegateContract), alice.privateKey);
-        vm.prank(alice.addr); // not needed to be alice herself - by design, anyone with the signed authorization can attach and submit
-        address(0).call("");
 
         assertGt(alice.addr.code.length, 0);
 

--- a/test/DelegateContractV4.t.sol
+++ b/test/DelegateContractV4.t.sol
@@ -38,38 +38,37 @@ contract DelegateContractV4Test is Test {
 
         /**
          * The storage layout of DelegateContractV3 is as follows:
-         * 
+         *
          * forge inspect DelegateContractV3 storageLayout
-            ╭-----------+--------------------------+------+--------+-------+-----------------------------------------------╮
-            | Name      | Type                     | Slot | Offset | Bytes | Contract                                      |
-            +==============================================================================================================+
-            | _status   | uint256                  | 0    | 0      | 32    | src/DelegateContractV3.sol:DelegateContractV3 |
-            |-----------+--------------------------+------+--------+-------+-----------------------------------------------|
-            | init      | bool                     | 1    | 0      | 1     | src/DelegateContractV3.sol:DelegateContractV3 |
-            |-----------+--------------------------+------+--------+-------+-----------------------------------------------|
-            | guardians | mapping(address => bool) | 2    | 0      | 32    | src/DelegateContractV3.sol:DelegateContractV3 |
-            ╰-----------+--------------------------+------+--------+-------+-----------------------------------------------╯
+         *         ╭-----------+--------------------------+------+--------+-------+-----------------------------------------------╮
+         *         | Name      | Type                     | Slot | Offset | Bytes | Contract                                      |
+         *         +==============================================================================================================+
+         *         | _status   | uint256                  | 0    | 0      | 32    | src/DelegateContractV3.sol:DelegateContractV3 |
+         *         |-----------+--------------------------+------+--------+-------+-----------------------------------------------|
+         *         | init      | bool                     | 1    | 0      | 1     | src/DelegateContractV3.sol:DelegateContractV3 |
+         *         |-----------+--------------------------+------+--------+-------+-----------------------------------------------|
+         *         | guardians | mapping(address => bool) | 2    | 0      | 32    | src/DelegateContractV3.sol:DelegateContractV3 |
+         *         ╰-----------+--------------------------+------+--------+-------+-----------------------------------------------╯
          */
 
         // Alice moves to V4
         vm.signAndAttachDelegation(address(delegateContractV4), alice.privateKey);
-        address(0).call("");
 
         /**
          * The storage layout of DelegateContractV4 is as follows:
-
+         *
          * forge inspect DelegateContractV4 storageLayout
-            ╭-----------+--------------------------+------+--------+-------+-----------------------------------------------╮
-            | Name      | Type                     | Slot | Offset | Bytes | Contract                                      |
-            +==============================================================================================================+
-            | _status   | uint256                  | 0    | 0      | 32    | src/DelegateContractV4.sol:DelegateContractV4 |
-            |-----------+--------------------------+------+--------+-------+-----------------------------------------------|
-            | paused    | bool                     | 1    | 0      | 1     | src/DelegateContractV4.sol:DelegateContractV4 |
-            |-----------+--------------------------+------+--------+-------+-----------------------------------------------|
-            | guardians | mapping(address => bool) | 2    | 0      | 32    | src/DelegateContractV4.sol:DelegateContractV4 |
-            ╰-----------+--------------------------+------+--------+-------+-----------------------------------------------╯
+         *         ╭-----------+--------------------------+------+--------+-------+-----------------------------------------------╮
+         *         | Name      | Type                     | Slot | Offset | Bytes | Contract                                      |
+         *         +==============================================================================================================+
+         *         | _status   | uint256                  | 0    | 0      | 32    | src/DelegateContractV4.sol:DelegateContractV4 |
+         *         |-----------+--------------------------+------+--------+-------+-----------------------------------------------|
+         *         | paused    | bool                     | 1    | 0      | 1     | src/DelegateContractV4.sol:DelegateContractV4 |
+         *         |-----------+--------------------------+------+--------+-------+-----------------------------------------------|
+         *         | guardians | mapping(address => bool) | 2    | 0      | 32    | src/DelegateContractV4.sol:DelegateContractV4 |
+         *         ╰-----------+--------------------------+------+--------+-------+-----------------------------------------------╯
          */
-        
+
         // Slot 0 continues to be ReentrancyGuard::_status
         assertEq(vm.load(alice.addr, 0), bytes32(0));
 


### PR DESCRIPTION
Hi @tinchoabbate , Thanks for creating youtube on this , i was so helpful for me 

when i was going through the tests , initially i was confused on this part - `address(0).call("")` like why this is needed 

and after asking AI , it has given me why as below 

address(0).call("");
– This is just “any transaction,” with an empty calldata to address 0. It doesn’t do anything on‐chain (it immediately returns false, since there is no code at address 0). However, it does count as “a transaction.” Because of how Foundry’s vm.signAndAttachDelegation(...) works, the next time you send any transaction from that EOA, the VM will first process the signed delegation (i.e. “swap in” delegateContract’s code as if Alice/Bob were their own contract wallets) and then execute the call.

Seems like this has been changed from Foundry side of how `vm.signAndAttachDelegation()` works 

i have tried removing it , still we can able to see all the test cases are passing 

